### PR TITLE
Fixes libcamopencv.initCam error

### DIFF
--- a/opencv/init.lua
+++ b/opencv/init.lua
@@ -26,13 +26,14 @@ function Camera:__init(...)
    self.tensorsized = torch.FloatTensor(3, height, width)
    self.buffer = torch.FloatTensor()
    self.tensortyped = torch.Tensor(3, height, width)
+   self.idx = idx
 
    -- init capture
-   self.idx = libcamopencv.initCam(idx, width, height)
+   self.fidx = libcamopencv.initCam(idx, width, height)
 end
 
 function Camera:forward()
-   libcamopencv.grabFrame(self.idx, self.buffer)
+   libcamopencv.grabFrame(self.fidx, self.buffer)
    if self.tensorsized:size(2) ~= self.buffer:size(2) or self.tensorsized:size(3) ~= self.buffer:size(3) then
       image.scale(self.buffer, self.tensorsized)
    else
@@ -47,6 +48,6 @@ function Camera:forward()
 end
 
 function Camera:stop()
-  libcamopencv.releaseCam(self.idx)
+  libcamopencv.releaseCam(self.fidx)
   print('stopping camera')
 end

--- a/opencv/opencv.c
+++ b/opencv/opencv.c
@@ -82,7 +82,7 @@ static int l_initCam(lua_State *L) {
   // next
   lua_pushnumber(L, fidx);
   fidx ++;
-  return 0;
+  return 1;
 }
 
 // frame grabber


### PR DESCRIPTION
This fixes an error with initCam caused by the C function l_initCam returning 0 instead of 1, so when it is called from Lua the return value is always nil.
