### PR TITLE
OpenCV init speed up by 10 seconds.

### DIFF
--- a/macos/camera.m
+++ b/macos/camera.m
@@ -439,7 +439,7 @@ int grabFrames(lua_State *L) {
 
     // get next tensor
     lua_rawgeti(L, 1, i+1);
-    THFloatTensor * tensor = luaT_checkudata(L, -1, luaT_checktypename2id(L, "torch.FloatTensor"));
+    THFloatTensor * tensor = luaT_toudata(L, -1, "torch.FloatTensor");
     lua_pop(L, 1);
 
     // grab frame

--- a/opencv/opencv.c
+++ b/opencv/opencv.c
@@ -32,12 +32,12 @@
 #define MAXIDX 100
 static CvCapture* capture[MAXIDX];
 static IplImage* frame[MAXIDX];
-static fidx = 0;
+static int fidx = 0;
 
 static int l_initCam(lua_State *L) {
   // args
-  int width = lua_tonumber(L, 2);
-  int height = lua_tonumber(L, 3);
+  //int width = lua_tonumber(L, 2);
+  //int height = lua_tonumber(L, 3);
 
   // max allocs ?
   if (fidx == MAXIDX) {
@@ -104,7 +104,7 @@ static int l_grabFrame (lua_State *L) {
   int m0 = tensor->stride[1];
   int m1 = tensor->stride[2];
   int m2 = tensor->stride[0];
-  unsigned char *src = frame[idx]->imageData;
+  unsigned char *src = (unsigned char *) frame[idx]->imageData;
   float *dst = THFloatTensor_data(tensor);
   int i, j, k;
   for (i=0; i < frame[idx]->height; i++) {

--- a/opencv/opencv.c
+++ b/opencv/opencv.c
@@ -57,6 +57,9 @@ static int l_initCam(lua_State *L) {
     //cvSetCaptureProperty(capture[fidx], CV_CAP_PROP_FRAME_HEIGHT, height);
     frame[fidx] = cvQueryFrame ( capture[fidx] );
     int tries = 10;
+    //while ((!frame[fidx] || frame[fidx]->height != height || frame[fidx]->width != width) && tries>0) {
+    //// The above while should only be used with cvSetCaptureProperty
+
     while ( !frame[fidx] && tries>0) {
       frame[fidx] = cvQueryFrame ( capture[fidx] );
       tries--;

--- a/opencv/opencv.c
+++ b/opencv/opencv.c
@@ -89,7 +89,7 @@ static int l_initCam(lua_State *L) {
 static int l_grabFrame (lua_State *L) {
   // Get Tensor's Info
   const int idx = lua_tonumber(L, 1);
-  THFloatTensor * tensor = luaT_checkudata(L, 2, luaT_checktypename2id(L, "torch.FloatTensor"));
+  THFloatTensor * tensor = luaT_toudata(L, 2, "torch.FloatTensor");
 
   // grab frame
   frame[idx] = cvQueryFrame ( capture[idx] );

--- a/opencv/opencv.c
+++ b/opencv/opencv.c
@@ -57,7 +57,7 @@ static int l_initCam(lua_State *L) {
     //cvSetCaptureProperty(capture[fidx], CV_CAP_PROP_FRAME_HEIGHT, height);
     frame[fidx] = cvQueryFrame ( capture[fidx] );
     int tries = 10;
-    while ((!frame[fidx] || frame[fidx]->height != height || frame[fidx]->width != width) && tries>0) {
+    while ( !frame[fidx] && tries>0) {
       frame[fidx] = cvQueryFrame ( capture[fidx] );
       tries--;
       sleep(1);


### PR DESCRIPTION
The OpenCV init function looped on a test for the cameras frame width and
height. If the cameras width or height was not the same as those passed in by
torch then the init was delayed by 10 seconds.
