### PR TITLE
Update camera-1.0-0.rockspec

### DIFF
--- a/camera-1.0-0.rockspec
+++ b/camera-1.0-0.rockspec
@@ -19,6 +19,7 @@ dependencies = {
    "torch >= 7.0",
    "xlua >= 1.0",
    "sys >= 1.0",
+   "image >= 1.0.1"
 }
 
 build = {


### PR DESCRIPTION
Camera won't work without the `image` package. I (think I) have added it (correctly) to the dependencies table list.
