### PR TITLE
BUGFIX in init.lua

### DIFF
--- a/opencv/init.lua
+++ b/opencv/init.lua
@@ -34,7 +34,7 @@ end
 function Camera:forward()
    libcamopencv.grabFrame(self.fidx, self.buffer)
    if self.tensorsized:size(2) ~= self.buffer:size(2) or self.tensorsized:size(3) ~= self.buffer:size(3) then
-      image.scale(self.buffer, self.tensorsized)
+      image.scale(self.tensorsized, self.buffer)
    else
       self.tensorsized = self.buffer
    end


### PR DESCRIPTION
Updated code using correct order of arguments for `image.scale()` (reflecting [this commit](https://github.com/torch/image/commit/62666b76b299b100c88931745f34c5835c251655))
